### PR TITLE
Remove MediaType from public api

### DIFF
--- a/src/main/java/com/github/princesslana/smalld/Attachment.java
+++ b/src/main/java/com/github/princesslana/smalld/Attachment.java
@@ -8,7 +8,6 @@ import java.io.InputStream;
 import java.net.URL;
 import java.util.concurrent.Callable;
 import java.util.function.Supplier;
-import okhttp3.MediaType;
 import okio.Buffer;
 
 /**
@@ -19,7 +18,7 @@ public class Attachment {
 
   private final String filename;
 
-  private final MediaType mediaType;
+  private final String mimeType;
 
   private final Supplier<InputStream> stream;
 
@@ -27,33 +26,33 @@ public class Attachment {
    * Create an instance with content from a byte array.
    *
    * @param filename the filename of this attachment
-   * @param mediaType the media type of this attachment
+   * @param mimeType the mime type of this attachment
    * @param bytes the content of this attachment
    */
-  public Attachment(String filename, MediaType mediaType, byte[] bytes) {
-    this(filename, mediaType, () -> new ByteArrayInputStream(bytes));
+  public Attachment(String filename, String mimeType, byte[] bytes) {
+    this(filename, mimeType, () -> new ByteArrayInputStream(bytes));
   }
 
   /**
    * Create an instance with content from the provided {@link File}.
    *
    * @param filename the filename of this attachment
-   * @param mediaType the media type of this attachment
+   * @param mimeType the mime type of this attachment
    * @param file file to retrieve content of this attachment
    */
-  public Attachment(String filename, MediaType mediaType, File file) {
-    this(filename, mediaType, supplyFrom(() -> new FileInputStream(file)));
+  public Attachment(String filename, String mimeType, File file) {
+    this(filename, mimeType, supplyFrom(() -> new FileInputStream(file)));
   }
 
   /**
    * Create an instance with content from the provided {@link URL}.
    *
    * @param filename the filename of this attachment
-   * @param mediaType the media type of this attachment
+   * @param mimeType the mime type of this attachment
    * @param url url to retrieve content of this attachment
    */
-  public Attachment(String filename, MediaType mediaType, URL url) {
-    this(filename, mediaType, supplyFrom(url::openStream));
+  public Attachment(String filename, String mimeType, URL url) {
+    this(filename, mimeType, supplyFrom(url::openStream));
   }
 
   /**
@@ -62,12 +61,12 @@ public class Attachment {
    * supplier it will use it to open an {@link InputStream}, read, and then close it.
    *
    * @param filename the filename of this attachment
-   * @param mediaType the media type of this attachment
+   * @param mimeType the mime type of this attachment
    * @param stream a supplier that can create an InputStream to get the content
    */
-  public Attachment(String filename, MediaType mediaType, Supplier<InputStream> stream) {
+  public Attachment(String filename, String mimeType, Supplier<InputStream> stream) {
     this.filename = filename;
-    this.mediaType = mediaType;
+    this.mimeType = mimeType;
     this.stream = stream;
   }
 
@@ -81,12 +80,12 @@ public class Attachment {
   }
 
   /**
-   * Return the media type.
+   * Return the mime type.
    *
-   * @return the media type
+   * @return the mime type
    */
-  public MediaType getMediaType() {
-    return mediaType;
+  public String getMimeType() {
+    return mimeType;
   }
 
   /**

--- a/src/main/java/com/github/princesslana/smalld/SmallD.java
+++ b/src/main/java/com/github/princesslana/smalld/SmallD.java
@@ -215,7 +215,9 @@ public class SmallD implements AutoCloseable {
 
     for (Attachment a : attachments) {
       builder.addFormDataPart(
-          "file", a.getFilename(), RequestBody.create(a.getMediaType(), a.getBytes()));
+          "file",
+          a.getFilename(),
+          RequestBody.create(MediaType.get(a.getMimeType()), a.getBytes()));
     }
 
     return sendRequest(path, b -> b.post(builder.build()));

--- a/src/main/java/com/github/princesslana/smalld/examples/CatBot.java
+++ b/src/main/java/com/github/princesslana/smalld/examples/CatBot.java
@@ -6,7 +6,6 @@ import com.github.princesslana.smalld.Attachment;
 import com.github.princesslana.smalld.SmallD;
 import java.io.IOException;
 import java.net.URL;
-import okhttp3.MediaType;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
@@ -54,7 +53,7 @@ public class CatBot {
     smalld.post(
         "/channels/" + channelId + "/messages",
         "",
-        new Attachment("cat.jpg", MediaType.get("image/jpeg"), getCatUrl()));
+        new Attachment("cat.jpg", "image/jpeg", getCatUrl()));
   }
 
   private static URL getCatUrl() {

--- a/src/test/java/com/github/princesslana/smalld/TestSmallD.java
+++ b/src/test/java/com/github/princesslana/smalld/TestSmallD.java
@@ -6,7 +6,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
-import okhttp3.MediaType;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.RecordedRequest;
 import okhttp3.mockwebserver.SocketPolicy;
@@ -480,7 +479,8 @@ public class TestSmallD {
   @Test
   public void post_whenMultipart_shouldReturnResponseOn200() {
     assertReturnsResponseOn200(
-        (s, path, payload) -> s.post(path, payload, new Attachment("", null, new byte[] {})));
+        (s, path, payload) ->
+            s.post(path, payload, new Attachment("", "text/plain", new byte[] {})));
   }
 
   @Test
@@ -546,7 +546,7 @@ public class TestSmallD {
 
     server.enqueue("");
 
-    subject.post("/test/url", "", new Attachment("", null, new byte[] {}));
+    subject.post("/test/url", "", new Attachment("", "text/plain", new byte[] {}));
 
     RecordedRequest req = server.takeRequest();
     assertThatRequestWas(req, "POST", "/test/url");
@@ -554,15 +554,13 @@ public class TestSmallD {
 
   @Test
   public void post_whenBytesAttachment_shouldSendMultipartBody() {
-    assertThatMultipartSendsBody(
-        new Attachment("abc", MediaType.get("text/plain"), "xyz".getBytes()));
+    assertThatMultipartSendsBody(new Attachment("abc", "text/plain", "xyz".getBytes()));
   }
 
   @Test
   public void post_whenUrlAttachment_shouldSendMultipartBody() {
     assertThatMultipartSendsBody(
-        new Attachment(
-            "abc", MediaType.get("text/plain"), getClass().getResource("multipart_input.txt")));
+        new Attachment("abc", "text/plain", getClass().getResource("multipart_input.txt")));
   }
 
   @Test


### PR DESCRIPTION
We would prefer to not expose okhttp3 classes via public apis. This is a step towards avoiding that.