### PR TITLE
Remove close listeners

### DIFF
--- a/src/main/java/com/github/princesslana/smalld/SmallD.java
+++ b/src/main/java/com/github/princesslana/smalld/SmallD.java
@@ -53,8 +53,6 @@ public class SmallD implements AutoCloseable {
 
   private final List<Consumer<String>> gatewayPayloadListeners = new ArrayList<>();
 
-  private final List<Runnable> closeListeners = new ArrayList<>();
-
   private final CountDownLatch closeGate = new CountDownLatch(1);
 
   private WebSocket gatewayWebSocket;
@@ -291,27 +289,13 @@ public class SmallD implements AutoCloseable {
     }
   }
 
-  /**
-   * Close the connection to Discord. Closes the websocket connection to the gateway and calls all
-   * {@link #onClose} listeners.
-   */
+  /** Close the connection to Discord. */
   public void close() {
     if (gatewayWebSocket != null) {
       gatewayWebSocket.close(1000, "Closed.");
     }
 
-    closeListeners.forEach(Runnable::run);
     closeGate.countDown();
-  }
-
-  /**
-   * Add a listener to be called when closed. It will be called after the Gateway has been
-   * disconnected.
-   *
-   * @param r a {@link Runnable} to be called on close.
-   */
-  public void onClose(Runnable r) {
-    closeListeners.add(r);
   }
 
   /** Connect and then await until closed. */

--- a/src/test/java/com/github/princesslana/smalld/TestSmallD.java
+++ b/src/test/java/com/github/princesslana/smalld/TestSmallD.java
@@ -3,7 +3,6 @@ package com.github.princesslana.smalld;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import okhttp3.mockwebserver.MockResponse;
@@ -604,22 +603,6 @@ public class TestSmallD {
           server.assertConnected();
           server.gateway().assertClosing(1000, "Closed.");
         });
-  }
-
-  @Test
-  public void close_whenConnected_shouldCallListener() {
-    CountDownLatch closeGate = new CountDownLatch(1);
-
-    server.enqueueConnect();
-
-    server.gateway().onOpen((ws, r) -> ws.send("DUMMY"));
-    subject.onGatewayPayload(m -> subject.close());
-
-    subject.onClose(closeGate::countDown);
-
-    subject.connect();
-
-    Assert.thatWithinOneSecond(closeGate::await);
   }
 
   @Test


### PR DESCRIPTION
Not currently used for anything, and a concept that can get messy when starting to consider reconnections