### PR TITLE
Refactor to use Consumer<SmallD> more

### DIFF
--- a/src/main/java/com/github/princesslana/smalld/Heartbeat.java
+++ b/src/main/java/com/github/princesslana/smalld/Heartbeat.java
@@ -5,49 +5,48 @@ import com.eclipsesource.json.JsonObject;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
 
 /**
  * Sends heartbeat payloads to the Discord Gateway. It will begin sending heartbeats after the HELLO
  * payload is received.
  */
-public class Heartbeat {
+public class Heartbeat implements Consumer<SmallD> {
 
   private final ScheduledExecutorService heartbeatExecutor =
       Executors.newSingleThreadScheduledExecutor(SmallD.DAEMON_THREAD_FACTORY);
 
-  private final SmallD smalld;
-
   private final SequenceNumber sequenceNumber;
 
   /**
-   * Constructs an instance that will send heartbeats via the provided {@link SmallD}.
+   * Constructs an instance that will send heartbeats.
    *
-   * @param smalld the {@link SmallD} to send heartbeat paylods through
    * @param sequenceNumber source from which to retrieve last seen sequence number
    */
-  public Heartbeat(SmallD smalld, SequenceNumber sequenceNumber) {
-
-    this.smalld = smalld;
+  public Heartbeat(SequenceNumber sequenceNumber) {
     this.sequenceNumber = sequenceNumber;
+  }
 
+  @Override
+  public void accept(SmallD smalld) {
     smalld.onGatewayPayload(
         s -> {
           JsonObject p = Json.parse(s).asObject();
 
           if (p.getInt("op", -1) == 10) {
-            onHello(p.get("d").asObject());
+            onHello(smalld, p.get("d").asObject());
           }
         });
   }
 
-  private void onHello(JsonObject d) {
+  private void onHello(SmallD smalld, JsonObject d) {
     long interval = d.getInt("heartbeat_interval", -1);
 
     heartbeatExecutor.scheduleAtFixedRate(
-        this::sendHeartbeat, interval, interval, TimeUnit.MILLISECONDS);
+        () -> sendHeartbeat(smalld), interval, interval, TimeUnit.MILLISECONDS);
   }
 
-  private void sendHeartbeat() {
+  private void sendHeartbeat(SmallD smalld) {
     smalld.sendGatewayPayload(
         Json.object()
             .add("op", 1)

--- a/src/main/java/com/github/princesslana/smalld/SequenceNumber.java
+++ b/src/main/java/com/github/princesslana/smalld/SequenceNumber.java
@@ -4,18 +4,15 @@ import com.eclipsesource.json.Json;
 import com.eclipsesource.json.JsonObject;
 import com.eclipsesource.json.JsonValue;
 import java.util.Optional;
+import java.util.function.Consumer;
 
 /** Tracks the last seen sequence number. */
-public class SequenceNumber {
+public class SequenceNumber implements Consumer<SmallD> {
 
   private Optional<Long> lastSeen = Optional.empty();
 
-  /**
-   * Construct an instance that will listen to payloads from the given {@link SmallD}.
-   *
-   * @param smalld the {@link SmallD} to listen for payloads from.
-   */
-  public SequenceNumber(SmallD smalld) {
+  @Override
+  public void accept(SmallD smalld) {
     smalld.onGatewayPayload(
         s -> {
           JsonObject p = Json.parse(s).asObject();

--- a/src/main/java/com/github/princesslana/smalld/SmallD.java
+++ b/src/main/java/com/github/princesslana/smalld/SmallD.java
@@ -10,6 +10,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
+import java.util.stream.Stream;
 import okhttp3.MediaType;
 import okhttp3.MultipartBody;
 import okhttp3.Request;
@@ -358,9 +359,11 @@ public class SmallD implements AutoCloseable {
   public static SmallD create(Config config) {
     SmallD smalld = new SmallD(config);
 
-    SequenceNumber seq = new SequenceNumber(smalld);
-    new Identify(seq).accept(smalld);
-    new Heartbeat(seq).accept(smalld);
+    SequenceNumber seq = new SequenceNumber();
+    Identify identify = new Identify(seq);
+    Heartbeat heartbeat = new Heartbeat(seq);
+
+    Stream.of(seq, identify, heartbeat).forEach(c -> c.accept(smalld));
 
     return smalld;
   }

--- a/src/main/java/com/github/princesslana/smalld/SmallD.java
+++ b/src/main/java/com/github/princesslana/smalld/SmallD.java
@@ -359,8 +359,8 @@ public class SmallD implements AutoCloseable {
     SmallD smalld = new SmallD(config);
 
     SequenceNumber seq = new SequenceNumber(smalld);
-    new Identify(smalld, seq);
-    new Heartbeat(smalld, seq);
+    new Identify(seq).accept(smalld);
+    new Heartbeat(seq).accept(smalld);
 
     return smalld;
   }

--- a/src/test/java/com/github/princesslana/smalld/TestHeartbeat.java
+++ b/src/test/java/com/github/princesslana/smalld/TestHeartbeat.java
@@ -7,8 +7,6 @@ import org.junit.jupiter.api.Test;
 
 public class TestHeartbeat {
 
-  private Heartbeat subject;
-
   private SmallD smalld;
 
   private MockDiscordServer server;
@@ -23,7 +21,7 @@ public class TestHeartbeat {
 
     smalld = server.newSmallD();
 
-    subject = new Heartbeat(smalld, new SequenceNumber(smalld));
+    new Heartbeat(new SequenceNumber(smalld)).accept(smalld);
   }
 
   @AfterEach

--- a/src/test/java/com/github/princesslana/smalld/TestHeartbeat.java
+++ b/src/test/java/com/github/princesslana/smalld/TestHeartbeat.java
@@ -21,7 +21,10 @@ public class TestHeartbeat {
 
     smalld = server.newSmallD();
 
-    new Heartbeat(new SequenceNumber(smalld)).accept(smalld);
+    SequenceNumber seq = new SequenceNumber();
+    Heartbeat h = new Heartbeat(seq);
+    
+    seq.andThen(h).accept(smalld);
   }
 
   @AfterEach

--- a/src/test/java/com/github/princesslana/smalld/TestHeartbeat.java
+++ b/src/test/java/com/github/princesslana/smalld/TestHeartbeat.java
@@ -23,7 +23,7 @@ public class TestHeartbeat {
 
     SequenceNumber seq = new SequenceNumber();
     Heartbeat h = new Heartbeat(seq);
-    
+
     seq.andThen(h).accept(smalld);
   }
 

--- a/src/test/java/com/github/princesslana/smalld/TestIdentify.java
+++ b/src/test/java/com/github/princesslana/smalld/TestIdentify.java
@@ -37,7 +37,7 @@ public class TestIdentify {
 
     smalld = server.newSmallD();
 
-    new Identify(smalld, new SequenceNumber(smalld));
+    new Identify(new SequenceNumber(smalld)).accept(smalld);
   }
 
   @AfterEach
@@ -106,7 +106,7 @@ public class TestIdentify {
   public void subject_whenShardSet_shouldSendShardDetail() {
     SmallD smalld = server.newSmallD(cfg -> cfg.setShard(2, 5));
 
-    new Identify(smalld, new SequenceNumber(smalld));
+    new Identify(new SequenceNumber(smalld)).accept(smalld);
 
     server.gateway().onOpen(SEND_HELLO);
 

--- a/src/test/java/com/github/princesslana/smalld/TestIdentify.java
+++ b/src/test/java/com/github/princesslana/smalld/TestIdentify.java
@@ -37,7 +37,10 @@ public class TestIdentify {
 
     smalld = server.newSmallD();
 
-    new Identify(new SequenceNumber(smalld)).accept(smalld);
+    SequenceNumber seq = new SequenceNumber();
+    Identify id = new Identify(seq);
+
+    seq.andThen(id).accept(smalld);
   }
 
   @AfterEach
@@ -106,7 +109,10 @@ public class TestIdentify {
   public void subject_whenShardSet_shouldSendShardDetail() {
     SmallD smalld = server.newSmallD(cfg -> cfg.setShard(2, 5));
 
-    new Identify(new SequenceNumber(smalld)).accept(smalld);
+    SequenceNumber seq = new SequenceNumber();
+    Identify id = new Identify(seq);
+
+    seq.andThen(id).accept(smalld);
 
     server.gateway().onOpen(SEND_HELLO);
 


### PR DESCRIPTION
`Consumer<SmallD>` seems to be a nice abstraction for things that'll run in SmallD. This moves Heartbeat and Identify to use that abstraction.